### PR TITLE
feature: SoftDeletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Standard Orbit drivers will respect the new key name and use that when creating,
 
 > 🚨 Changing the key for a model after records already exist can cause damage. Be sure to rename your files afterwards so that Orbit doesn't create duplicate content.
 
+### Soft Deletes
+
+Since Orbit needs to update files on disk when your model is updated, the standard Eloquent `SoftDeletes` trait doesn't quite work. If you want to add soft delete support to your Orbit model, you can instead use the `Orbit\Concerns\SoftDeletes` trait.
+
+This trait uses the Eloquent one under-the-hood, so you can still access all of your normal `SoftDeletes` methods, including `isForceDeleting()` and `forceDelete()`. 
+
+The Orbit version adds in the necessary hooks to perform file system operations as well as ensure you don't completely delete your content.
+
 ## Drivers
 
 Orbit is a driver-based package, making it very easy to change the storage format of your data.

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -35,6 +35,10 @@ trait Orbital
         }
 
         static::created(function (Model $model) {
+            if ($this->callTraitMethod('shouldCreate') === false) {
+                return;
+            }
+
             $status = Orbit::driver(static::getOrbitalDriver())->save(
                 $model,
                 static::getOrbitalPath()
@@ -46,6 +50,10 @@ trait Orbital
         });
 
         static::updated(function (Model $model) {
+            if ($this->callTraitMethod('shouldUpdate') === false) {
+                return;
+            }
+
             $status = Orbit::driver(static::getOrbitalDriver())->save(
                 $model,
                 static::getOrbitalPath()
@@ -57,6 +65,10 @@ trait Orbital
         });
 
         static::deleted(function (Model $model) {
+            if ($this->callTraitMethod('shouldDelete') === false) {
+                return;
+            }
+
             $status = Orbit::driver(static::getOrbitalDriver())->delete(
                 $model,
                 static::getOrbitalPath()
@@ -92,13 +104,7 @@ trait Orbital
         static::resolveConnection()->getSchemaBuilder()->create($table, function (Blueprint $table) {
             static::schema($table);
 
-            foreach (class_uses_recursive(static::class) as $trait) {
-                $method = 'schema' . Str::of($trait)->classBasename();
-
-                if (method_exists($this, $method)) {
-                    $this->{$method}($table);
-                }
-            }
+            $this->callTraitMethod('schema', $table);
 
             if ($this->usesTimestamps()) {
                 $table->timestamps();
@@ -150,5 +156,20 @@ trait Orbital
     public static function getOrbitalPath()
     {
         return \config('orbit.paths.content') . DIRECTORY_SEPARATOR . static::getOrbitalName();
+    }
+
+    public function callTraitMethod(string $method, ...$args)
+    {
+        $result = null;
+
+        foreach (class_uses_recursive(static::class) as $trait) {
+            $methodToCall = $method . Str::of($trait)->classBasename();
+
+            if (method_exists($this, $methodToCall)) {
+                $result = $this->{$methodToCall}(...$args);
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -35,7 +35,7 @@ trait Orbital
         }
 
         static::created(function (Model $model) {
-            if ($this->callTraitMethod('shouldCreate') === false) {
+            if ($model->callTraitMethod('shouldCreate', $model) === false) {
                 return;
             }
 
@@ -50,7 +50,7 @@ trait Orbital
         });
 
         static::updated(function (Model $model) {
-            if ($this->callTraitMethod('shouldUpdate') === false) {
+            if ($model->callTraitMethod('shouldUpdate', $model) === false) {
                 return;
             }
 
@@ -65,7 +65,7 @@ trait Orbital
         });
 
         static::deleted(function (Model $model) {
-            if ($this->callTraitMethod('shouldDelete') === false) {
+            if ($model->callTraitMethod('shouldDelete', $model) === false) {
                 return;
             }
 

--- a/src/Concerns/SoftDeletes.php
+++ b/src/Concerns/SoftDeletes.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Eloquent\SoftDeletes as EloquentSoftDeletes;
+use Orbit\Events\OrbitalUpdated;
 
 trait SoftDeletes
 {
@@ -24,6 +25,16 @@ trait SoftDeletes
             );
 
             OrbitalDeleted::dispatch($model);
+
+            return $status;
+        });
+
+        static::restored(function (Model $model) {
+            $status = Orbit::driver(static::getOrbitalDriver())->save(
+                $model, static::getOrbitalPath()
+            );
+
+            OrbitalUpdated::dispatch($model);
 
             return $status;
         });

--- a/src/Concerns/SoftDeletes.php
+++ b/src/Concerns/SoftDeletes.php
@@ -40,7 +40,7 @@ trait SoftDeletes
         });
 
         static::forceDeleted(function (Model $model) {
-            if ($model->callTraitMethod('shouldDelete', $model) === false) {
+            if ($model->callTraitMethod('shouldForceDelete', $model) === false) {
                 return;
             }
 

--- a/src/Concerns/SoftDeletes.php
+++ b/src/Concerns/SoftDeletes.php
@@ -2,13 +2,47 @@
 
 namespace Orbit\Concerns;
 
-use Illuminate\Database\Eloquent\SoftDeletes as EloquentSoftDeletes;
+use Orbit\Facades\Orbit;
+use Orbit\Events\OrbitalDeleted;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ColumnDefinition;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\SoftDeletes as EloquentSoftDeletes;
 
 trait SoftDeletes
 {
     use EloquentSoftDeletes;
+
+    public static function bootSoftDeletes()
+    {
+        static::addGlobalScope(new SoftDeletingScope);
+
+        static::deleted(function (Model $model) {
+            $status = Orbit::driver(static::getOrbitalDriver())->save(
+                $model, static::getOrbitalPath()
+            );
+
+            OrbitalDeleted::dispatch($model);
+
+            return $status;
+        });
+
+        static::forceDeleted(function (Model $model) {
+            if ($model->callTraitMethod('shouldDelete', $model) === false) {
+                return;
+            }
+
+            $status = Orbit::driver(static::getOrbitalDriver())->delete(
+                $model,
+                static::getOrbitalPath()
+            );
+
+            OrbitalDeleted::dispatch($model);
+
+            return $status;
+        });
+    }
 
     public function schemaSoftDeletes(Blueprint $table)
     {
@@ -21,5 +55,10 @@ trait SoftDeletes
         }
 
         $table->softDeletes($this->getDeletedAtColumn());
+    }
+
+    public function shouldDeleteSoftDeletes()
+    {
+        return $this->isForceDeleting();
     }
 }

--- a/src/Concerns/SoftDeletes.php
+++ b/src/Concerns/SoftDeletes.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Orbit\Concerns;
+
+use Illuminate\Database\Eloquent\SoftDeletes as EloquentSoftDeletes;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
+
+trait SoftDeletes
+{
+    use EloquentSoftDeletes;
+
+    public function schemaSoftDeletes(Blueprint $table)
+    {
+        $hasSoftDeletesColumn = collect($table->getColumns())->contains(function (ColumnDefinition $column) {
+            return $column->get('name') === $this->getDeletedAtColumn();
+        });
+
+        if ($hasSoftDeletesColumn) {
+            return;
+        }
+
+        $table->softDeletes($this->getDeletedAtColumn());
+    }
+}


### PR DESCRIPTION
Closes #3.

This pull request adds a new `Orbit\Concerns\SoftDeletes` trait that can be used on an Orbit model to add support for soft deleting. It handles all of the schema logic, as well as updating the files and re-caching.