### PR TITLE
fix: content directory names

### DIFF
--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -161,7 +161,7 @@ trait Orbital
 
     public static function getOrbitalName()
     {
-        return (string) Str::of(class_basename(static::class))->lower()->snake()->plural();
+        return (string) Str::of(class_basename(static::class))->snake()->lower()->plural();
     }
 
     public static function getOrbitalPath()

--- a/tests/AdvancedOrbitalTest.php
+++ b/tests/AdvancedOrbitalTest.php
@@ -19,7 +19,7 @@ class AdvancedOrbitalTest extends TestCase
             'name' => 'Ryan',
         ]);
 
-        $this->assertFileExists(__DIR__.'/content/customkeys/'.$custom->name.'.md');
+        $this->assertFileExists(__DIR__.'/content/custom_keys/'.$custom->name.'.md');
     }
 
     public function test_it_can_update_files_using_custom_primary_key()
@@ -28,14 +28,14 @@ class AdvancedOrbitalTest extends TestCase
             'name' => 'Ryan',
         ]);
 
-        $this->assertFileExists(__DIR__.'/content/customkeys/'.$custom->name.'.md');
+        $this->assertFileExists(__DIR__.'/content/custom_keys/'.$custom->name.'.md');
 
         $custom->update([
             'name' => 'John',
         ]);
 
-        $this->assertFileDoesNotExist(__DIR__.'/content/customkeys/Ryan.md');
-        $this->assertFileExists(__DIR__.'/content/customkeys/'.$custom->name.'.md');
+        $this->assertFileDoesNotExist(__DIR__.'/content/custom_keys/Ryan.md');
+        $this->assertFileExists(__DIR__.'/content/custom_keys/'.$custom->name.'.md');
     }
 
     public function test_it_can_use_a_custom_driver()
@@ -44,6 +44,6 @@ class AdvancedOrbitalTest extends TestCase
             'name' => 'Ryan',
         ]);
 
-        $this->assertFileExists(__DIR__.'/content/jsonmodels/'.$json->getKey().'.json');
+        $this->assertFileExists(__DIR__.'/content/json_models/'.$json->getKey().'.json');
     }
 }

--- a/tests/SoftDeletesTest.php
+++ b/tests/SoftDeletesTest.php
@@ -16,7 +16,7 @@ class SoftDeletesTest extends TestCase
 
         $this->assertNotEmpty($post->deleted_at);
 
-        $file = file_get_contents(__DIR__.'/content/softdeletedposts/'.$post->id.'.md');
+        $file = file_get_contents(__DIR__.'/content/soft_deleted_posts/'.$post->id.'.md');
 
         $this->assertStringContainsString(sprintf('deleted_at: \'%s\'', $post->deleted_at), $file);
     }
@@ -31,13 +31,13 @@ class SoftDeletesTest extends TestCase
 
         $this->assertNotEmpty($post->deleted_at);
 
-        $file = file_get_contents(__DIR__.'/content/softdeletedposts/'.$post->id.'.md');
+        $file = file_get_contents(__DIR__.'/content/soft_deleted_posts/'.$post->id.'.md');
 
         $this->assertStringContainsString(sprintf('deleted_at: \'%s\'', $post->deleted_at), $file);
 
         $post->forceDelete();
 
-        $this->assertFileDoesNotExist(__DIR__.'/content/softdeletedposts/'.$post->id.'.md');
+        $this->assertFileDoesNotExist(__DIR__.'/content/soft_deleted_posts/'.$post->id.'.md');
     }
 
     public function test_it_will_remove_deleted_at_when_restoring_file()
@@ -50,13 +50,13 @@ class SoftDeletesTest extends TestCase
 
         $this->assertNotEmpty($post->deleted_at);
 
-        $file = file_get_contents(__DIR__.'/content/softdeletedposts/'.$post->id.'.md');
+        $file = file_get_contents(__DIR__.'/content/soft_deleted_posts/'.$post->id.'.md');
 
         $this->assertStringContainsString(sprintf('deleted_at: \'%s\'', $post->deleted_at), $file);
 
         $post->restore();
 
-        $file = file_get_contents(__DIR__.'/content/softdeletedposts/'.$post->id.'.md');
+        $file = file_get_contents(__DIR__.'/content/soft_deleted_posts/'.$post->id.'.md');
 
         $this->assertStringNotContainsString('deleted_at', $file);
     }


### PR DESCRIPTION
Closes #13. This is a **breaking change**, if you've already got directories that were created automatically, you'll need to rename them to follow a pluralised, lower snake case format, i.e. `my_models`.