### PR TITLE
feature: register database connection

### DIFF
--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -21,7 +21,6 @@ trait Orbital
     public static function bootOrbital()
     {
         static::ensureOrbitDirectoriesExist();
-        static::setSqliteConnection();
 
         $driver = Orbit::driver(static::getOrbitalDriver());
         $modelFile = (new ReflectionClass(static::class))->getFileName();
@@ -88,7 +87,12 @@ trait Orbital
 
     public static function resolveConnection($connection = null)
     {
-        return static::$orbit;
+        return static::$resolver->connection('orbit');
+    }
+
+    public function getConnectionName()
+    {
+        return 'orbit';
     }
 
     public function migrate()
@@ -128,14 +132,6 @@ trait Orbital
     protected static function getOrbitalDriver()
     {
         return property_exists(static::class, 'driver') ? static::$driver : null;
-    }
-
-    protected static function setSqliteConnection()
-    {
-        static::$orbit = app(ConnectionFactory::class)->make([
-            'driver' => 'sqlite',
-            'database' => Orbit::getDatabasePath(),
-        ]);
     }
 
     protected static function ensureOrbitDirectoriesExist()

--- a/src/OrbitServiceProvider.php
+++ b/src/OrbitServiceProvider.php
@@ -10,6 +10,7 @@ use Orbit\Events\OrbitalCreated;
 use Orbit\Events\OrbitalDeleted;
 use Orbit\Events\OrbitalForceDeleted;
 use Orbit\Events\OrbitalUpdated;
+use Orbit\Facades\Orbit;
 use Orbit\Listeners\ProcessGitTransaction;
 
 class OrbitServiceProvider extends ServiceProvider
@@ -33,6 +34,14 @@ class OrbitServiceProvider extends ServiceProvider
 
             return $manager;
         });
+
+        $config = $this->app['config'];
+
+        $config->set('database.connections.orbit', [
+            'driver' => 'sqlite',
+            'database' => Orbit::getDatabasePath(),
+            'foreign_key_constraints' => false,
+        ]);
     }
 
     public function boot()


### PR DESCRIPTION
This pull request moves away from dynamically resolving the connection using `resolveConnection` and instead registers a custom connection in `database.connections.orbit`.

This means that any existing Laravel features that rely on connection names, i.e. `Rule::exists`, `Rule::unique`, relationships will continue to work as expected without any issues.