### PR TITLE
Adds Validation Rule format for use with Orbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ class StorePostRequest extends FormRequest
   }
 ```
 
-> 🚨 When using the shorter format, i.e. `'slug' => 'required|alpha_dasg|unique:post',`, Laravel will try to load up a real database connection which may not exist and cause your app to crash.
-
 ## Drivers
 
 Orbit is a driver-based package, making it very easy to change the storage format of your data.

--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ This trait uses the Eloquent one under-the-hood, so you can still access all of 
 
 The Orbit version adds in the necessary hooks to perform file system operations as well as ensure you don't completely delete your content.
 
-### Form Requests
+### Validation Rules
 
-When dealing with [Form Requests](https://laravel.com/docs/8.x/validation#form-request-validation) using [validation rules](https://laravel.com/docs/8.x/validation#available-validation-rules) to check against a database like [`exists`](https://laravel.com/docs/8.x/validation#rule-exists) and [`unique`](https://laravel.com/docs/8.x/validation#rule-unique), use the Eloquent Model format.
+When dealing with [validation rules](https://laravel.com/docs/8.x/validation#available-validation-rules) that check against a database like [`exists`](https://laravel.com/docs/8.x/validation#rule-exists) and [`unique`](https://laravel.com/docs/8.x/validation#rule-unique), you should use the **fully-qualified namespace (FQN) of the model** instead of the table name.
+
+This is because Orbit runs on a separate database connection - using the FQN will allow Laravel to correctly resolve the qualified table name.
 
 ```php
 class StorePostRequest extends FormRequest
@@ -113,7 +115,8 @@ class StorePostRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'slug' => 'required|alpha_dasg|unique:App\Post,id',
+            'slug' => 'required|alpha_dash|unique:App\Post,id',
+            // 'slug' => ['required', 'alpha_dash', Rule::unique(Post::class)],
             'title' => 'required',
             'description' => 'required',
         ];

--- a/README.md
+++ b/README.md
@@ -98,6 +98,31 @@ This trait uses the Eloquent one under-the-hood, so you can still access all of 
 
 The Orbit version adds in the necessary hooks to perform file system operations as well as ensure you don't completely delete your content.
 
+### Form Requests
+
+When dealing with [Form Requests](https://laravel.com/docs/8.x/validation#form-request-validation) using [validation rules](https://laravel.com/docs/8.x/validation#available-validation-rules) to check against a database like [`exists`](https://laravel.com/docs/8.x/validation#rule-exists) and [`unique`](https://laravel.com/docs/8.x/validation#rule-unique), use the Eloquent Model format.
+
+```php
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'slug' => 'required|alpha_dasg|unique:App\Post,id',
+            'title' => 'required',
+            'description' => 'required',
+        ];
+    }
+  }
+```
+
+> 🚨 When using the shorter format, i.e. `'slug' => 'required|alpha_dasg|unique:post',`, Laravel will try to load up a real database connection which may not exist and cause your app to crash.
+
 ## Drivers
 
 Orbit is a driver-based package, making it very easy to change the storage format of your data.


### PR DESCRIPTION
*Background*
After adding this package to an existing Laravel project by following the description in the Readme file, I started to test out the Laravel project functionality and ended up seeing errors when trying to save Models.

After some investigation, I found out that the custom Form Requests I have created to validate my form submissions were using rules that require verification of existence or uniqueness of an entry into a database table. That was done using the builtin Laravel Validation Rules `exists` and `unique`.

*Solution*
Realising that this package heavily relies in the Model itself to act, I've decided to change the rule format to the alternative Eloquent (Model) format, which uses the Eloquent fully qualified name (FQN) instead of the database table name. Doing so, we force Laravel to directly use the Model which uses Orbit behind the scenes instead of going to the database and search for the table name and make the checks.

With this change, this specific behaviour is now visible for others that may face the same situation.

*Notes*
Please, feel free to amend the text I've added to the Readme and test the solution yourself before accepting this PR.