### PR TITLE
Prefix namespace with \

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To begin using Orbit, create a Laravel model and use the `Orbit\Concerns\Orbital
 ```php
 class Post extends Model
 {
-    use Orbit\Concerns\Orbital;
+    use \Orbit\Concerns\Orbital;
 }
 ```
 
@@ -39,7 +39,7 @@ use Illuminate\Database\Schema\Blueprint;
 
 class Post extends Model
 {
-    use Orbit\Concerns\Orbital;
+    use \Orbit\Concerns\Orbital;
 
     public static function schema(Blueprint $table)
     {


### PR DESCRIPTION
It's sort of ugly, but now it's copypastable. Alternatively there could be a `use` statement above the class, but if there's the full namespace for the trait path, it makes sense to have it actually copypastable.