### PR TITLE
feature: better Git integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "illuminate/support": "^8.0",
         "ryangjchandler/git": "^0.0.4",
         "spatie/yaml-front-matter": "^2.0",
-        "symfony/yaml": "^3.0 || ^4.0 || ^5.0",
-        "symplify/git-wrapper": "^9.2"
+        "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.15",

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
+        "illuminate/console": "^8.0",
         "illuminate/database": "^8.0",
         "illuminate/events": "^8.0",
         "illuminate/support": "^8.0",
-        "illuminate/console": "^8.0",
+        "ryangjchandler/git": "^0.0.4",
         "spatie/yaml-front-matter": "^2.0",
         "symfony/yaml": "^3.0 || ^4.0 || ^5.0",
         "symplify/git-wrapper": "^9.2"

--- a/config/orbit.php
+++ b/config/orbit.php
@@ -22,6 +22,7 @@ return [
         'email' => env('ORBIT_GIT_EMAIL'),
         'root' => env('ORBIT_GIT_ROOT', base_path()),
         'binary' => env('ORBIT_GIT_BINARY', '/usr/bin/git'),
+        'message_template' => 'orbit: {event} {model} {primary_key}'
     ],
 
 ];

--- a/src/Commands/CommitCommand.php
+++ b/src/Commands/CommitCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Orbit\Commands;
+
+use Error;
+use Orbit\Facades\Orbit;
+use RyanChandler\Git\Git;
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class CommitCommand extends Command
+{
+    protected $signature = 'orbit:commit {message?}';
+
+    protected $description = 'Commit and push Orbit content changes to Git.';
+
+    public function handle()
+    {
+        if (Orbit::isTesting() || ! config('orbit.git.enabled')) {
+            return 0;
+        }
+
+        /** @var \RyanChandler\Git\Git $git */
+        $git = Git::open(
+            Orbit::getGitRoot()
+        );
+
+        $git->add(
+            config('orbit.paths.content')
+        );
+
+        try {
+            $git->commit(
+                $this->argument('message') ?? 'orbit: changes committed manually'
+            );
+        } catch (ProcessFailedException $e) {
+            $this->error('Failed to commit changes. [Message] ' . $e->getMessage());
+
+            return 1;
+        }
+
+        $git->push();
+
+        $this->info('Succesfully committed and pushed the latest Orbit content changes.');
+
+        return 0;
+    }
+}

--- a/src/Commands/CommitCommand.php
+++ b/src/Commands/CommitCommand.php
@@ -16,7 +16,7 @@ class CommitCommand extends Command
 
     public function handle()
     {
-        if (Orbit::isTesting() || ! config('orbit.git.enabled')) {
+        if (Orbit::isTesting()) {
             return 0;
         }
 

--- a/src/Commands/PullCommand.php
+++ b/src/Commands/PullCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Orbit\Commands;
+
+use Orbit\Facades\Orbit;
+use RyanChandler\Git\Git;
+use Illuminate\Console\Command;
+
+class PullCommand extends Command
+{
+    protected $name = 'orbit:pull';
+
+    protected $description = 'Pull the latest Git changes.';
+
+    public function handle()
+    {
+        if (Orbit::isTesting() || ! config('orbit.git.enabled')) {
+            return 0;
+        }
+
+        /** @var \RyanChandler\Git\Git $git */
+        $git = Git::open(
+            Orbit::getGitRoot()
+        );
+
+        $git->pull();
+
+        $this->info('Succesfully pulled the latest changes from Git.');
+
+        $path = Orbit::getDatabasePath();
+
+        if (! file_exists($path)) {
+            return 0;
+        }
+
+        unlink($path);
+
+        $this->info('Succesfully cleared the Orbit cache.');
+
+        return 0;
+    }
+}

--- a/src/Listeners/ProcessGitTransaction.php
+++ b/src/Listeners/ProcessGitTransaction.php
@@ -41,6 +41,7 @@ class ProcessGitTransaction
 
     protected function commit(array $keys)
     {
+        return;
         /** @var \RyanChandler\Git\Git $git */
         $git = Git::open(
             Orbit::getGitRoot()

--- a/src/OrbitServiceProvider.php
+++ b/src/OrbitServiceProvider.php
@@ -53,6 +53,7 @@ class OrbitServiceProvider extends ServiceProvider
                 Commands\ClearCommand::class,
                 Commands\FreshCommand::class,
                 Commands\PullCommand::class,
+                Commands\CommitCommand::class,
             ]);
 
             $this->publishes([

--- a/src/OrbitServiceProvider.php
+++ b/src/OrbitServiceProvider.php
@@ -52,6 +52,7 @@ class OrbitServiceProvider extends ServiceProvider
             $this->commands([
                 Commands\ClearCommand::class,
                 Commands\FreshCommand::class,
+                Commands\PullCommand::class,
             ]);
 
             $this->publishes([


### PR DESCRIPTION
Closes #53 and #55. 

This pull request introduces a better Git integration. You can now change the commit message that is used for automatic Git commits.

This string has 3 template strings available, `{event}`, `{model}` and `{primary_key}`. The `event` key will be the name of the event, e.g. `created`, `updated`, `deleted`, and `force deleted`.

The `model` is the `class_basename` of the model and the `primary_key` is the return value of `$model->getKey()`. 

There's also 2 new commands - `orbit:pull` and `orbit:commit`.

`orbit:pull` will pull the latest Git changes for the entire repository and clear the Orbit cache (something you'd normally do in your deploy script). `orbit:commit` will let you manually commit any changes inside of the `content` folder and optional provide a message, `orbit:commit "My custom message"`.

If you've got a `ORBIT_GIT_ENABLED` set to `false`, `orbit:pull` won't do anything. The `orbit:commit` command will still work though, letting you manually commit your changes whenever you like.