### PR TITLE
feature: add orbit:generate command

### DIFF
--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Orbit\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
+
+class GenerateCommand extends Command
+{
+    protected $signature = 'orbit:generate {model}';
+
+    protected $description = 'Quickly create a new Orbit record.';
+
+    public function handle()
+    {
+        $model = $this->qualifyModelClass();
+        $data = $this->getColumnsFromModel($model)->mapWithKeys(function (string $name): array {
+            $value = $this->ask(Str::title($name));
+
+            return [$name => $value];
+        })->all();
+
+        /**
+         * @psalm-suppress InvalidStringClass
+         */
+        $model::create($data);
+
+        $this->info('Model created successfully.');
+    }
+
+    protected function getColumnsFromModel(string $modelClass): Collection
+    {
+        $blueprint = new Blueprint('__orbit:generate__');
+
+        /**
+         * @psalm-suppress InvalidStringClass
+         */
+        $modelClass::schema($blueprint);
+
+        return collect($blueprint->getColumns())->map(function (ColumnDefinition $column): string {
+            return $column->getAttributes()['name'];
+        });
+    }
+
+    protected function qualifyModelClass(): string
+    {
+        $rootNamespace = app()->getNamespace();
+
+        $prefixes = [
+            $rootNamespace,
+            $rootNamespace.'Models\\',
+        ];
+
+        foreach ($prefixes as $prefix) {
+            $namespaced = $prefix.$this->argument('model');
+
+            if (class_exists($namespaced)) {
+                return $namespaced;
+            }
+        }
+
+        $this->error('Model does not exist.');
+
+        exit(1);
+    }
+}

--- a/src/OrbitServiceProvider.php
+++ b/src/OrbitServiceProvider.php
@@ -54,6 +54,7 @@ class OrbitServiceProvider extends ServiceProvider
                 Commands\FreshCommand::class,
                 Commands\PullCommand::class,
                 Commands\CommitCommand::class,
+                Commands\GenerateCommand::class,
             ]);
 
             $this->publishes([

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,2 @@
+providers:
+  - Orbit\OrbitServiceProvider


### PR DESCRIPTION
Closes #65.

This pull request introduces a new `orbit:generate` command that will look at the `schema` definition for the model and ask you to enter data for each column.

It can be used like so:

```bash
artisan orbit:generate Post
```

This will look for either an `App\Post` class or `App\Models\Post` class and use the `schema` definition. It will then use `$this->ask()` to get the data.

**Todo**:
* [x] Convert stringy booleans to actual booleans, i.e. `'true` => true`.
* [x] Check if a column is nullable and convert empty string to `null`.