### PR TITLE
Allow enable/disable Orbit dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 build
 .phpunit.result.cache
+.idea

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -21,6 +21,10 @@ trait Orbital
 
     public static function bootOrbital()
     {
+        if (!static::orbitEnabled()) {
+            return;
+        }
+
         static::ensureOrbitDirectoriesExist();
 
         $driver = Orbit::driver(static::getOrbitalDriver());
@@ -88,12 +92,20 @@ trait Orbital
 
     public static function resolveConnection($connection = null)
     {
-        return static::$resolver->connection('orbit');
+        if (static::orbitEnabled()) {
+            return static::$resolver->connection('orbit');
+        }
+
+        return parent::resolveConnection($connection);
     }
 
     public function getConnectionName()
     {
-        return 'orbit';
+        if (static::orbitEnabled()) {
+            return 'orbit';
+        }
+
+        return parent::getConnectionName();
     }
 
     public function migrate()
@@ -197,5 +209,10 @@ trait Orbital
         }
 
         return $result;
+    }
+
+    public static function orbitEnabled(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
The use case is I have a blog platform that I want users to select flat-file database or mysql and I don't want to have 2 models in the code base.

This PR allows to enable/disable Orbit by overriding this method in the Model class. It still set to true by default.

```php
public static function orbitEnabled(): bool
{
    return true;
}
```