### PR TITLE
feature: support nested files (using patterns)

### DIFF
--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -89,7 +89,7 @@ trait Orbital
                 $meta = OrbitMeta::forOrbital($model);
 
                 if ($meta->file_path_read_from !== $path) {
-                    (new Filesystem)->delete($meta->file_path_read_from);
+                    (new Filesystem())->delete($meta->file_path_read_from);
 
                     $meta->update([
                         'file_path_read_from' => $path,

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -48,7 +48,7 @@ trait Orbital
 
             $status = Orbit::driver(static::getOrbitalDriver())->save(
                 $model,
-                static::getOrbitalPath()
+                static::generateOrbitalFilePathForModel($model)
             );
 
             event(new OrbitalCreated($model));
@@ -63,7 +63,7 @@ trait Orbital
 
             $status = Orbit::driver(static::getOrbitalDriver())->save(
                 $model,
-                static::getOrbitalPath()
+                static::generateOrbitalFilePathForModel($model)
             );
 
             event(new OrbitalUpdated($model));
@@ -78,7 +78,7 @@ trait Orbital
 
             $status = Orbit::driver(static::getOrbitalDriver())->delete(
                 $model,
-                static::getOrbitalPath()
+                static::generateOrbitalFilePathForModel($model)
             );
 
             event(new OrbitalDeleted($model));
@@ -205,6 +205,18 @@ trait Orbital
     public static function getOrbitalPath()
     {
         return \config('orbit.paths.content') . DIRECTORY_SEPARATOR . static::getOrbitalName();
+    }
+
+    public static function getOrbitalPathPattern(): ?string
+    {
+        return null;
+    }
+
+    public static function generateOrbitalFilePathForModel(Model $model)
+    {
+        if (static::getOrbitalPathPattern() === null) {
+            return static::getOrbitalPath();
+        }
     }
 
     public function callTraitMethod(string $method, ...$args)

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -222,7 +222,7 @@ trait Orbital
         $pattern = static::getOrbitalPathPattern();
         $path = static::getOrbitalPath() . DIRECTORY_SEPARATOR . Support::buildPathForPattern($pattern, $model);
 
-        (new Filesystem)->ensureDirectoryExists($path);
+        (new Filesystem())->ensureDirectoryExists($path);
 
         return $path;
     }

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -11,6 +11,7 @@ use Orbit\Events\OrbitalCreated;
 use Orbit\Events\OrbitalDeleted;
 use Orbit\Events\OrbitalUpdated;
 use Orbit\Facades\Orbit;
+use Orbit\Support;
 use ReflectionClass;
 
 trait Orbital
@@ -217,6 +218,13 @@ trait Orbital
         if (static::getOrbitalPathPattern() === null) {
             return static::getOrbitalPath();
         }
+
+        $pattern = static::getOrbitalPathPattern();
+        $path = static::getOrbitalPath() . DIRECTORY_SEPARATOR . Support::buildPathForPattern($pattern, $model);
+
+        (new Filesystem)->ensureDirectoryExists($path);
+
+        return $path;
     }
 
     public function callTraitMethod(string $method, ...$args)

--- a/src/Concerns/SoftDeletes.php
+++ b/src/Concerns/SoftDeletes.php
@@ -23,7 +23,7 @@ trait SoftDeletes
         static::deleted(function (Model $model) {
             $status = Orbit::driver(static::getOrbitalDriver())->save(
                 $model,
-                static::getOrbitalPath()
+                static::generateOrbitalFilePathForModel($model)
             );
 
             event(new OrbitalDeleted($model));
@@ -34,7 +34,7 @@ trait SoftDeletes
         static::restored(function (Model $model) {
             $status = Orbit::driver(static::getOrbitalDriver())->save(
                 $model,
-                static::getOrbitalPath()
+                static::generateOrbitalFilePathForModel($model)
             );
 
             event(new OrbitalUpdated($model));
@@ -49,7 +49,7 @@ trait SoftDeletes
 
             $status = Orbit::driver(static::getOrbitalDriver())->delete(
                 $model,
-                static::getOrbitalPath()
+                static::generateOrbitalFilePathForModel($model)
             );
 
             event(new OrbitalForceDeleted($model));

--- a/src/Drivers/FileDriver.php
+++ b/src/Drivers/FileDriver.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Orbit\Contracts\Driver as DriverContract;
 use Orbit\Facades\Orbit;
+use Orbit\Models\OrbitMeta;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -26,6 +27,7 @@ abstract class FileDriver implements DriverContract
         return $highest > filemtime(Orbit::getDatabasePath());
     }
 
+    /** @param Model&\Orbit\Concerns\Orbital $model */
     public function save(Model $model, string $directory): bool
     {
         if ($model->wasChanged($model->getKeyName())) {
@@ -69,13 +71,15 @@ abstract class FileDriver implements DriverContract
                 continue;
             }
 
-            $collection->push($this->parseContent($file));
+            $collection->push(array_merge($this->parseContent($file), [
+                'file_path_read_from' => $file->getRealPath(),
+            ]));
         }
 
         return $collection;
     }
 
-    protected function filepath(string $directory, string $key): string
+    public function filepath(string $directory, string $key): string
     {
         return $directory . DIRECTORY_SEPARATOR . $key . '.' . $this->extension();
     }

--- a/src/Drivers/FileDriver.php
+++ b/src/Drivers/FileDriver.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Orbit\Contracts\Driver as DriverContract;
 use Orbit\Facades\Orbit;
-use Orbit\Models\OrbitMeta;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;

--- a/src/Drivers/FileDriver.php
+++ b/src/Drivers/FileDriver.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Orbit\Contracts\Driver as DriverContract;
 use Orbit\Facades\Orbit;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use SplFileInfo;
 
 abstract class FileDriver implements DriverContract
@@ -51,9 +53,18 @@ abstract class FileDriver implements DriverContract
     public function all(string $directory): Collection
     {
         $collection = Collection::make();
-        $files = new FilesystemIterator($directory);
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS));
 
-        foreach ($files as $file) {
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->isDir()) {
+                $files = $this->all($file->getRealPath());
+
+                $collection->merge($files);
+
+                continue;
+            }
+
             if ($file->getExtension() !== $this->extension()) {
                 continue;
             }

--- a/src/Models/OrbitMeta.php
+++ b/src/Models/OrbitMeta.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orbit\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/** @test */
+final class OrbitMeta extends Model
+{
+    protected $table = '_orbit_meta';
+
+    protected $connection = 'orbit';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function orbital()
+    {
+        $class = $this->orbital_type;
+
+        return $class::find($this->orbital_key);
+    }
+
+    public static function forOrbital(Model $model)
+    {
+        return static::query()->where('orbital_type', $model::class)->where('orbital_key', $model->getKey())->first();
+    }
+}

--- a/src/OrbitServiceProvider.php
+++ b/src/OrbitServiceProvider.php
@@ -7,10 +7,12 @@ use Illuminate\Database\Events\DatabaseRefreshed;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Orbit\Actions\ClearCache;
 use Orbit\Contracts\Driver;
 use Orbit\Facades\Orbit;
+use Orbit\Models\OrbitMeta;
 
 class OrbitServiceProvider extends ServiceProvider
 {
@@ -55,6 +57,17 @@ class OrbitServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../config/orbit.php' => config_path('orbit.php'),
             ], 'orbit:config');
+        }
+
+        if (! Schema::connection('orbit')->hasTable('_orbit_meta')) {
+            Schema::connection('orbit')->create('_orbit_meta', function (Blueprint $table) {
+                $table->id();
+                $table->string('orbital_type')->index();
+                $table->string('orbital_key')->index();
+                $table->string('file_path_read_from')->nullable();
+            });
+        } else {
+            OrbitMeta::truncate();
         }
 
         Event::listen(DatabaseRefreshed::class, ClearCache::class);

--- a/src/Support.php
+++ b/src/Support.php
@@ -4,7 +4,6 @@ namespace Orbit;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 
 /** @internal */
 final class Support

--- a/src/Support.php
+++ b/src/Support.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Orbit;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+
+/** @internal */
+final class Support
+{
+    public static function buildPathForPattern(string $pattern, Model $model)
+    {
+        $parts = explode('/', $pattern);
+        $path = '';
+
+        foreach ($parts as $i => $part) {
+            if ($i !== 0) {
+                $path .= '/';
+            }
+
+            // This part of the pattern is a binding. We need to strip the {} and get the property from the model.
+            if (str_starts_with($part, '{') && str_ends_with($part, '}')) {
+                $binding = explode(':', trim($part, '{}'));
+
+                [$property, $args] = count($binding) > 1 ?
+                    [$binding[0], explode(',', $binding[1])] :
+                    [$binding[0], []];
+
+                $value = $model->{$property};
+
+                if ($value instanceof Carbon && isset($args[0])) {
+                    $path .= $value->format($args[0]);
+                } else {
+                    $path .= (string) $value;
+                }
+            } else {
+                $path .= $part;
+            }
+        }
+
+        return $path;
+    }
+}

--- a/tests/CustomFilePathsTest.php
+++ b/tests/CustomFilePathsTest.php
@@ -55,7 +55,7 @@ class CustomFilePathsTest extends TestCase
     {
         CustomFilePathModel::create([
             'slug' => Str::slug('foo bar'),
-            'published_at' => now(),
+            'published_at' => Carbon::parse('2022-02-12'),
         ]);
 
         $this->assertFileExists(__DIR__ . '/content/custom_file_path_models/2022-02-12/foo-bar.md');
@@ -85,5 +85,23 @@ class CustomFilePathsTest extends TestCase
         $this->assertEquals('rick-roll', $record->slug);
         $this->assertInstanceOf(Carbon::class, $record->published_at);
         $this->assertEquals('2022-04-01', $record->published_at->format('Y-m-d'));
+    }
+
+    /** @test */
+    public function it_removes_old_custom_file_paths_for_stale_data()
+    {
+        $record = CustomFilePathModel::create([
+            'slug' => 'bob-baz',
+            'published_at' => Carbon::parse('2022-06-12'),
+        ]);
+
+        $this->assertFileExists(__DIR__ . '/content/custom_file_path_models/2022-06-12/bob-baz.md');
+
+        $record->update([
+            'published_at' => Carbon::parse('2022-08-12'),
+        ]);
+
+        $this->assertFileExists(__DIR__ . '/content/custom_file_path_models/2022-08-12/bob-baz.md');
+        $this->assertFileDoesNotExist(__DIR__ . '/content/custom_file_path_models/2022-06-12/bob-baz.md');
     }
 }

--- a/tests/CustomFilePathsTest.php
+++ b/tests/CustomFilePathsTest.php
@@ -3,12 +3,11 @@
 namespace Orbit\Tests;
 
 use Carbon\Carbon;
-use Faker\Core\File;
-use Illuminate\Support\Str;
-use Orbit\Concerns\Orbital;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Orbit\Concerns\Orbital;
 
 class CustomFilePathModel extends Model
 {
@@ -48,7 +47,7 @@ class CustomFilePathsTest extends TestCase
     {
         parent::setUp();
 
-        (new Filesystem)->deleteDirectory(__DIR__ . '/content/custom_file_path_models');
+        (new Filesystem())->deleteDirectory(__DIR__ . '/content/custom_file_path_models');
     }
 
     /** @test */
@@ -65,9 +64,9 @@ class CustomFilePathsTest extends TestCase
     /** @test */
     public function it_can_read_files_stored_in_a_custom_path()
     {
-        (new Filesystem)->ensureDirectoryExists(__DIR__ . '/content/custom_file_path_models/2022-04-01');
+        (new Filesystem())->ensureDirectoryExists(__DIR__ . '/content/custom_file_path_models/2022-04-01');
 
-        (new Filesystem)->put(
+        (new Filesystem())->put(
             __DIR__ . '/content/custom_file_path_models/2022-04-01/rick-roll.md',
             <<<md
             ---

--- a/tests/CustomFilePathsTest.php
+++ b/tests/CustomFilePathsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Orbit\Tests;
+
+use Carbon\Carbon;
+use Faker\Core\File;
+use Illuminate\Support\Str;
+use Orbit\Concerns\Orbital;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Filesystem\Filesystem;
+
+class CustomFilePathModel extends Model
+{
+    use Orbital;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+    ];
+
+    public static function schema(Blueprint $table)
+    {
+        $table->string('slug')->unique();
+        $table->string('published_at');
+    }
+
+    public static function getOrbitalPathPattern(): ?string
+    {
+        return '{published_at:Y-m-d}';
+    }
+
+    public function getKeyName()
+    {
+        return 'slug';
+    }
+
+    public function getIncrementing()
+    {
+        return false;
+    }
+}
+
+class CustomFilePathsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        (new Filesystem)->deleteDirectory(__DIR__ . '/content/custom_file_path_models');
+    }
+
+    /** @test */
+    public function it_can_be_stored_in_a_custom_path()
+    {
+        CustomFilePathModel::create([
+            'slug' => Str::slug('foo bar'),
+            'published_at' => now(),
+        ]);
+
+        $this->assertFileExists(__DIR__ . '/content/custom_file_path_models/2022-02-12/foo-bar.md');
+    }
+
+    /** @test */
+    public function it_can_read_files_stored_in_a_custom_path()
+    {
+        (new Filesystem)->ensureDirectoryExists(__DIR__ . '/content/custom_file_path_models/2022-04-01');
+
+        (new Filesystem)->put(
+            __DIR__ . '/content/custom_file_path_models/2022-04-01/rick-roll.md',
+            <<<md
+            ---
+            slug: rick-roll
+            published_at: 2022-04-01T15:50:10+00:00
+            created_at: 2022-02-12T15:50:10+00:00
+            updated_at: 2022-02-12T15:50:10+00:00
+            ---
+            md
+        );
+
+        $this->assertFileExists(__DIR__ . '/content/custom_file_path_models/2022-04-01/rick-roll.md');
+
+        $record = CustomFilePathModel::find('rick-roll');
+
+        $this->assertEquals('rick-roll', $record->slug);
+        $this->assertInstanceOf(Carbon::class, $record->published_at);
+        $this->assertEquals('2022-04-01', $record->published_at->format('Y-m-d'));
+    }
+}


### PR DESCRIPTION
This pull request introduces support for nested files inside of the content directory.

It uses a pattern-based file path generator, very similar to Laravel's routing patterns. Here's a simple example you might use for a blog.

```php
class Post extends Model
{
	use Orbital;

	public $incrementing = false;

	public static function schema($table)
	{
		$table->string('slug')->unique();
		$table->timestamp('published_at');
	}

	public static function getKeyName()
	{
		return 'slug';
	}

	public static function getOrbitalPathPattern(): ?string
	{
		return '{published_at:Y-m-d}';
	}
}
```

If you had the slug `foo-bar` and published_at of `2022-04-01 00:00:00`, a new model will be written to `content/posts/2022-04-01/foo-bar.md`.

At this point in time, custom file paths are purely organisational. This means that the pattern for your file paths will **not** be used to resolve the values for your model. **All data** will still be stored in the file.

Custom file paths should always be unique. In theory, you'll never have any issues since Orbit will use the primary-key for your model as the file name which is always unique anyway. 

> **NOTE** - custom file path patterns are fully supported by the first-party drivers. Custom drivers implemented by third-parties will be able to save the files, but stale file paths (i.e. data used to generate the file path has been changed) won't be cleaned up automatically. Forcing this would be a breaking change and I'm not sure there's many people with custom drivers anyway.

**TODO:**
* [x] Store files in `content` directory based on the custom file path.
* [x] If model data changes, delete the old file for that model.