### PR TITLE
Add orbit:cache command

### DIFF
--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -58,7 +58,6 @@ class CacheCommand extends Command
                 }
 
                 $reflection = new ReflectionClass($class);
-                // Only include non-abstract Model classes that use the Oribtal trait
                 return $reflection->isSubclassOf(Model::class) &&
                     ! $reflection->isAbstract() &&
                     isset(class_uses_recursive($class)[Orbital::class]);

--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -2,8 +2,8 @@
 
 namespace Orbit\Commands;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Orbit\Concerns\Orbital;
@@ -19,13 +19,14 @@ class CacheCommand extends Command
     {
         $models = $this->findOrbitModels();
 
-        if ($models->count() === 0) {
+        if ($models->isEmpty()) {
             $this->warn('Could not find any Orbit models.');
+
             return 0;
         }
 
-        $models->each(function (string $modelName): void {
-            (new $modelName())->migrate();
+        $models->each(function (string $model): void {
+            (new $model())->migrate();
         });
 
         $this->info('Cached the following Orbit models:');
@@ -52,15 +53,15 @@ class CacheCommand extends Command
                 return $class;
             })
             ->filter(function ($class) {
-                if (class_exists($class)) {
-                    $reflection = new ReflectionClass($class);
-                    // Only include non-abstract Model classes that use the Oribtal trait
-                    return $reflection->isSubclassOf(Model::class) &&
-                        !$reflection->isAbstract() &&
-                        isset(class_uses_recursive($class)[Orbital::class]);
+                if (! class_exists($class)) {
+                    return false;
                 }
 
-                return false;
+                $reflection = new ReflectionClass($class);
+                // Only include non-abstract Model classes that use the Oribtal trait
+                return $reflection->isSubclassOf(Model::class) &&
+                    ! $reflection->isAbstract() &&
+                    isset(class_uses_recursive($class)[Orbital::class]);
             });
     }
 }

--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Orbit\Commands;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Orbit\Concerns\Orbital;
+use ReflectionClass;
+
+class CacheCommand extends Command
+{
+    protected $name = 'orbit:cache';
+
+    protected $descripition = 'Cache all Orbit models.';
+
+    public function handle()
+    {
+        $models = $this->findOrbitModels();
+
+        if ($models->count() === 0) {
+            $this->warn('Could not find any Orbit models.');
+            return 0;
+        }
+
+        $models->each(function (string $modelName): void {
+            (new $modelName())->migrate();
+        });
+
+        $this->info('Cached the following Orbit models:');
+        $this->newLine();
+        $this->line($models->map(fn ($model) => "• <info>{$model}</info>"));
+
+        return 0;
+    }
+
+    protected function findOrbitModels(): Collection
+    {
+        return collect(File::allFiles(app_path()))
+            ->map(function ($item) {
+                // Convert file path to namespace
+                $path = $item->getRelativePathName();
+                $class = sprintf(
+                    '\%s%s',
+                    app()->getNamespace(),
+                    strtr(substr($path, 0, strrpos($path, '.')), '/', '\\')
+                );
+
+                return $class;
+            })
+            ->filter(function ($class) {
+                if (class_exists($class)) {
+                    $reflection = new ReflectionClass($class);
+                    // Only include non-abstract Model classes that use the Oribtal trait
+                    return $reflection->isSubclassOf(Model::class) &&
+                        !$reflection->isAbstract() &&
+                        isset(class_uses_recursive($class)[Orbital::class]);
+                }
+
+                return false;
+            });
+    }
+}

--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -37,13 +37,15 @@ class CacheCommand extends Command
 
     protected function findOrbitModels(): Collection
     {
-        return collect(File::allFiles(app_path()))
-            ->map(function ($item) {
+        $laravel = $this->getApplication()->getLaravel();
+
+        return collect(File::allFiles($laravel->path()))
+            ->map(function ($item) use ($laravel) {
                 // Convert file path to namespace
                 $path = $item->getRelativePathName();
                 $class = sprintf(
                     '\%s%s',
-                    app()->getNamespace(),
+                    $laravel->getNamespace().'\\',
                     strtr(substr($path, 0, strrpos($path, '.')), '/', '\\')
                 );
 

--- a/src/OrbitServiceProvider.php
+++ b/src/OrbitServiceProvider.php
@@ -56,6 +56,7 @@ class OrbitServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                Commands\CacheCommand::class,
                 Commands\ClearCommand::class,
                 Commands\FreshCommand::class,
                 Commands\GenerateCommand::class,

--- a/tests/CacheCommandTest.php
+++ b/tests/CacheCommandTest.php
@@ -21,8 +21,9 @@ class CacheCommandTest extends TestCase
         $this->setAppNamespace('Orbit\\Tests\\Fixtures\\Cache');
     
         $this->artisan('orbit:cache')
-            ->expectsOutputToContain('Cached the following Orbit models:')
-            ->expectsOutputToContain('Orbit\\Tests\\Fixtures\\Cache\\CachePost');
+            ->expectsOutput("Cached the following Orbit models:")
+            ->expectsOutput("• \Orbit\Tests\Fixtures\Cache\CachePost");
+        ;
 
         $this->assertCount(1, DB::connection('orbit')->table('cache_posts')->get());
     }
@@ -33,7 +34,7 @@ class CacheCommandTest extends TestCase
         $this->setAppNamespace('Foo\\');
 
         $this->artisan('orbit:cache')
-            ->expectsOutputToContain('Could not find any Orbit models.');
+            ->expectsOutput('Could not find any Orbit models.');
     }
 
     private function setAppNamespace(string $namespace): void

--- a/tests/CacheCommandTest.php
+++ b/tests/CacheCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Orbit\Tests;
+
+use Illuminate\Foundation\Application as LaravelApplication;
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery\MockInterface;
+use Orbit\Commands\CacheCommand;
+use Orbit\Tests\Fixtures\Cache\CachePost;
+use Illuminate\Console\Application as ConsoleApplication;
+use Illuminate\Support\Facades\DB;
+use ReflectionClass;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CacheCommandTest extends TestCase
+{
+    public function test_it_caches_found_models()
+    {
+        $this->app->useAppPath(__DIR__.'/Fixtures/Cache');
+        $this->setAppNamespace('Orbit\\Tests\\Fixtures\\Cache');
+    
+        $this->artisan('orbit:cache')
+            ->expectsOutputToContain('Cached the following Orbit models:')
+            ->expectsOutputToContain('Orbit\\Tests\\Fixtures\\Cache\\CachePost');
+
+        $this->assertCount(1, DB::connection('orbit')->table('cache_posts')->get());
+    }
+
+    public function test_it_caches_no_models()
+    {
+        $this->app->useAppPath(__DIR__.'/Fixtures/Cache');
+        $this->setAppNamespace('Foo\\');
+
+        $this->artisan('orbit:cache')
+            ->expectsOutputToContain('Could not find any Orbit models.');
+    }
+
+    private function setAppNamespace(string $namespace): void
+    {
+        $reflection = new ReflectionClass($this->app);
+        $reflectionNamespace = $reflection->getProperty('namespace');
+        $reflectionNamespace->setAccessible(true);
+        $reflectionNamespace->setValue($this->app, $namespace);
+        $reflectionNamespace->setAccessible(false);
+    }
+}
+
+

--- a/tests/Fixtures/Cache/CachePost.php
+++ b/tests/Fixtures/Cache/CachePost.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Orbit\Tests\Fixtures\Cache;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Orbit\Concerns\Orbital;
+
+class CachePost extends Model
+{
+    use Orbital;
+
+    public static function schema(Blueprint $table)
+    {
+        $table->id();
+        $table->string('title');
+        $table->string('slug')->nullable();
+        $table->text('content')->nullable();
+    }
+}

--- a/tests/content/cache_posts/1.md
+++ b/tests/content/cache_posts/1.md
@@ -1,0 +1,6 @@
+---
+title: test
+slug: my-slug
+created_at: 2022-03-11T10:15:12+00:00
+updated_at: 2022-03-11T10:15:12+00:00
+---


### PR DESCRIPTION
This PR adds an `orbit:cache` command which finds all non-abstract Model classes anywhere within your `app_path()` that use the Orbital trait and calls `migrate()` on them.

The only drawback I can see is that if you were including Orbital Models from Composer dependencies in `vendor` they would not be migrated by this command, but I don't know if you want to go to that level with this command.


Example output:

> No models found:
> <img width="355" alt="Screen Shot 2022-03-11 at 9 17 59 pm" src="https://user-images.githubusercontent.com/52687/157849831-9698b90d-1576-41e0-9afc-ea648967cc5e.png">
> Models found:
> <img width="360" alt="Screen Shot 2022-03-11 at 9 17 35 pm" src="https://user-images.githubusercontent.com/52687/157849840-bbc44dbf-1049-4759-a056-997943821a7f.png">



Closes #102