### PR TITLE
getLaravel directly from CacheCommand

### DIFF
--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -38,7 +38,7 @@ class CacheCommand extends Command
 
     protected function findOrbitModels(): Collection
     {
-        $laravel = $this->getApplication()->getLaravel();
+        $laravel = $this->getLaravel();
 
         return collect(File::allFiles($laravel->path()))
             ->map(function ($item) use ($laravel) {


### PR DESCRIPTION
This fixes the PHPStan warning introduced in the CacheCommand.

The warning was cause because in Laravel `Command::getApplication` should generally return an `Illuminate\Console\Application`, but is typehinted to return a `Symfony\Component\Console\Application` (which does not have a `getLaravel` function). We cut out the middle step by just calling `getLaravel` directly on the command.

Should I modify the `.github/workflows/phpstan.yml` action to be triggered by pull request as well?