### PR TITLE
Run phpstan workflow on pull_request

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
 
 jobs:
   phpstan:


### PR DESCRIPTION
This PR makes the `phpstan.yml` workflow run on `pull_request`.

As per the [workflow docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request):

> By default, only the `opened`, `synchronize`, and `reopened` activity types trigger workflows that run on the `pull_request` event. 

which is a sensible default for the `phpstan.yml` workflow.

(Note that it's not going to run on this PR as it's only triggered on changes to `**.php` or `phpstan.neon.dist` files.)