### PR TITLE
Add Git Integration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,7 @@ class Post extends Model
     }
 }
 ```
+
+## Git Integration
+
+Since `v1.0.0` this package no longer supports the git integration. Instead you can use [jubeki/orbit-git](https://Jubeki/orbit-git) as replacement.

--- a/README.md
+++ b/README.md
@@ -237,4 +237,4 @@ class Post extends Model
 
 ## Git Integration
 
-Since `v1.0.0` this package no longer supports the git integration. Instead you can use [jubeki/orbit-git](https://Jubeki/orbit-git) as replacement.
+Since `v1.0.0` this package no longer supports the git integration. Instead you can use [jubeki/orbit-git](https://github.com/Jubeki/orbit-git) as replacement.


### PR DESCRIPTION
Since `v1.0.0` doesn't support the git integration anymore, I extracted the parts out of `v0.9.1` and created a package for that. 

EDIT:
Package available here: https://github.com/Jubeki/orbit-git