### PR TITLE
fix: only null out nullable columns in content files

### DIFF
--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -200,7 +200,7 @@ trait Orbital
                 foreach ($columns as $column) {
                     $definition = $blueprint->orbitGetColumn($column);
 
-                    if (! array_key_exists($column, $newRow) && !! $definition['nullable']) {
+                    if (! array_key_exists($column, $newRow) && ! ! $definition['nullable']) {
                         $newRow[$column] = null;
                     }
                 }

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -198,11 +198,13 @@ trait Orbital
                 }
 
                 foreach ($columns as $column) {
+                    if (array_key_exists($column, $newRow)) {
+                        continue;
+                    }
+
                     $definition = $blueprint->orbitGetColumn($column);
 
-                    if (! array_key_exists($column, $newRow) && ! ! $definition['nullable']) {
-                        $newRow[$column] = null;
-                    }
+                    $newRow[$column] = $definition->nullable ? null : $definition->default;
                 }
 
                 return $newRow;

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -204,7 +204,11 @@ trait Orbital
 
                     $definition = $blueprint->orbitGetColumn($column);
 
-                    $newRow[$column] = $definition->nullable ? null : $definition->default;
+                    if ($definition->default) {
+                        $newRow[$column] = $definition->default;
+                    } elseif ($definition->nullable) {
+                        $newRow[$column] = null;
+                    }
                 }
 
                 return $newRow;

--- a/src/OrbitServiceProvider.php
+++ b/src/OrbitServiceProvider.php
@@ -91,5 +91,10 @@ class OrbitServiceProvider extends ServiceProvider
                 fn (ColumnDefinition $column) => $column->get('name') === $name
             );
         });
+
+        Blueprint::macro('orbitGetColumn', function (string $name): ?ColumnDefinition {
+            /** @var \Illuminate\Database\Schema\Blueprint $this */
+            return collect($this->getColumns())->firstWhere('name', $name);
+        });
     }
 }

--- a/tests/DefaultDatabaseValuesTest.php
+++ b/tests/DefaultDatabaseValuesTest.php
@@ -4,6 +4,7 @@ namespace Orbit\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Orbit\Concerns\Orbital;
 
 class DefaultValues extends Model
@@ -17,6 +18,19 @@ class DefaultValues extends Model
         $table->bigIncrements('id');
         $table->string('name');
         $table->string('email')->default('foo@test.com');
+    }
+}
+
+class MissingRow extends Model
+{
+    use Orbital;
+
+    protected $guarded = [];
+
+    public static function schema(Blueprint $table)
+    {
+        $table->bigIncrements('id');
+        $table->string('country')->default('United Kingdom');
     }
 }
 
@@ -38,5 +52,19 @@ class DefaultDatabaseValuesTest extends TestCase
         $contents = file_get_contents(__DIR__.'/content/default_values/'.$model->id.'.md');
 
         $this->assertStringContainsString('email: foo@test.com', $contents);
+    }
+
+    public function test_missing_values_use_default_in_database()
+    {
+        file_put_contents(__DIR__ . '/content/missing_rows/1.md', <<<'md'
+        ---
+        id: 1
+        ---
+        md);
+
+        $this->assertCount(1, MissingRow::all());
+        $this->assertEquals(1, MissingRow::first()->getKey());
+
+        MissingRow::all()->each->delete();
     }
 }

--- a/tests/DefaultDatabaseValuesTest.php
+++ b/tests/DefaultDatabaseValuesTest.php
@@ -4,7 +4,6 @@ namespace Orbit\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Orbit\Concerns\Orbital;
 
 class DefaultValues extends Model

--- a/tests/DefaultDatabaseValuesTest.php
+++ b/tests/DefaultDatabaseValuesTest.php
@@ -61,8 +61,16 @@ class DefaultDatabaseValuesTest extends TestCase
         ---
         md);
 
-        $this->assertCount(1, MissingRow::all());
+        file_put_contents(__DIR__ . '/content/missing_rows/2.md', <<<'md'
+        ---
+        id: 2
+        country: Spain
+        ---
+        md);
+
+        $this->assertCount(2, MissingRow::all());
         $this->assertEquals(1, MissingRow::first()->getKey());
+        $this->assertEquals(2, MissingRow::find(2)->getKey());
 
         MissingRow::all()->each->delete();
     }

--- a/tests/content/missing_rows/.gitignore
+++ b/tests/content/missing_rows/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!missing_rows


### PR DESCRIPTION
Closes #107.

This was throwing an exception because Orbit was defaulting any missing columns/data to `null`, which would only work if a field was nullable.

I'm surprised this hasn't come up sooner.