### PR TITLE
Add ability to create dynamic schema for Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 build
 .phpunit.result.cache
 *.cache
+/.idea
+/.vscode

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -158,6 +158,10 @@ trait Orbital
         static::resolveConnection()->getSchemaBuilder()->create($table, function (Blueprint $table) use (&$blueprint) {
             static::schema($table);
 
+            foreach (Orbit::dynamicSchemaCallback($table->getTable()) as $schmeCallback) {
+                $schmeCallback($table);
+            }
+
             $this->callTraitMethod('schema', $table);
 
             $driver = Orbit::driver(static::getOrbitalDriver());

--- a/src/Concerns/Orbital.php
+++ b/src/Concerns/Orbital.php
@@ -158,7 +158,7 @@ trait Orbital
         static::resolveConnection()->getSchemaBuilder()->create($table, function (Blueprint $table) use (&$blueprint) {
             static::schema($table);
 
-            foreach (Orbit::dynamicSchemaCallback($table->getTable()) as $schmeCallback) {
+            foreach (Orbit::dynamicSchemaCallbacks($table->getTable()) as $schmeCallback) {
                 $schmeCallback($table);
             }
 

--- a/src/Facades/Orbit.php
+++ b/src/Facades/Orbit.php
@@ -15,6 +15,8 @@ use Orbit\OrbitManager;
  * @method static string getContentPath()
  * @method static \Orbit\OrbitManager test()
  * @method static bool isTesting()
+ * @method static void registerDynamicSchema()
+ * @method static array dynamicSchemaCallbacks(string $table)
  *
  * @see \Orbit\OrbitManager
  */

--- a/src/OrbitManager.php
+++ b/src/OrbitManager.php
@@ -9,6 +9,8 @@ class OrbitManager extends Manager
 {
     protected $testing = false;
 
+    protected array $dynamicSchemaCallbacks = [];
+
     public function test()
     {
         $this->testing = true;
@@ -43,5 +45,18 @@ class OrbitManager extends Manager
     public function getContentPath()
     {
         return config('orbit.paths.content');
+    }
+
+    public function registerDynamicSchema(string $table, \Closure $schemaCallback): void
+    {
+        $this->dynamicSchemaCallbacks[$table] = array_merge(
+            $this->dynamicSchemaCallbacks[$table] ?? [],
+            [$schemaCallback]
+        );
+    }
+
+    public function dynamicSchemaCallbacks(string $table): array
+    {
+        return $this->dynamicSchemaCallbacks[$table] ?? [];
     }
 }


### PR DESCRIPTION
Make Orbit able to create schema outside the model class.

```php
Orbit::registerDynamicSchema('posts', function (Blueprint $table) {
    $table->string('external_url')->nullable();
});
```

This will add `external_url` column to the `posts` table.