### PR TITLE
Keep snake-casing for backwards compatibility

### DIFF
--- a/src/OrbitOptions.php
+++ b/src/OrbitOptions.php
@@ -61,7 +61,7 @@ final class OrbitOptions
 
     public function getSource(Model $model): string
     {
-        $source = $this->source ?? Str::of($model::class)->classBasename()->kebab()->plural();
+        $source = $this->source ?? Str::of($model::class)->classBasename()->snake()->plural();
 
         if (is_dir($source)) {
             return $source;


### PR DESCRIPTION
For two word models e.g. `ProductVariation` in v1 the `source` was `content/product_variations/` like a standard MySQL database table naming convention.

In v2 the case was switched to `kebab` case. i.e. `content/product-variations/`

This had two effects: created new empty kebab-cased directories, and failed to find existing data.