### PR TITLE
Fix exception from autoloading when running `orbit:cache`

### DIFF
--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -46,7 +46,7 @@ class CacheCommand extends Command
                 $path = $item->getRelativePathName();
                 $class = sprintf(
                     '\%s%s',
-                    $laravel->getNamespace().'\\',
+                    $laravel->getNamespace(),
                     strtr(substr($path, 0, strrpos($path, '.')), '/', '\\')
                 );
 

--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -53,7 +53,7 @@ class CacheCommand extends Command
                 return $class;
             })
             ->filter(function ($class) {
-                if (! class_exists($class, false)) {
+                if (! class_exists($class)) {
                     return false;
                 }
 

--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -53,7 +53,7 @@ class CacheCommand extends Command
                 return $class;
             })
             ->filter(function ($class) {
-                if (! class_exists($class)) {
+                if (! class_exists($class, false)) {
                     return false;
                 }
 

--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -44,9 +44,10 @@ class CacheCommand extends Command
             ->map(function ($item) use ($laravel) {
                 // Convert file path to namespace
                 $path = $item->getRelativePathName();
+                $ns = $laravel->getNamespace();
                 $class = sprintf(
                     '\%s%s',
-                    $laravel->getNamespace(),
+                    str_ends_with($ns, "\\") ? $ns : $ns."\\",
                     strtr(substr($path, 0, strrpos($path, '.')), '/', '\\')
                 );
 


### PR DESCRIPTION
When running `php artisan orbit:cache` with a simple model on a fresh install, the following error occurred:

> Cannot declare class App\Console\Kernel, because the name is already in use

Digging into the code a bit, I found out that the second argument to `class_exists` determines whether or not to [autoload the class](https://www.php.net/manual/en/function.class-exists.php) you're testing. And, the default value is `true`.

Marking this `false` fixed the issue for me.