### PR TITLE
Typo in CacheCommand.php

### DIFF
--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -13,7 +13,7 @@ class CacheCommand extends Command
 {
     protected $name = 'orbit:cache';
 
-    protected $descripition = 'Cache all Orbit models.';
+    protected $description = 'Cache all Orbit models.';
 
     public function handle()
     {


### PR DESCRIPTION
Hello Ryan,

Just a little type here : 

`protected $descripition = 'Cache all Orbit models.';`

The submitted file fixes this.

Have a nice day.