### PR TITLE
Add Allowed Plugins to avoid CI Errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,10 @@
         "test": "vendor/bin/phpunit --colors=always"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "pestphp/pest-plugin": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "phpstan/extension-installer": true,
-            "pestphp/pest-plugin": true
+            "phpstan/extension-installer": true
         }
     }
 }


### PR DESCRIPTION
Adding the allowed plugins to `composer.json` file, to avoid CI Errors