### PR TITLE
feat: add csv driver

### DIFF
--- a/config/orbit.php
+++ b/config/orbit.php
@@ -8,6 +8,7 @@ return [
         'md' => \Orbit\Drivers\Markdown::class,
         'json' => \Orbit\Drivers\Json::class,
         'yaml' => \Orbit\Drivers\Yaml::class,
+        'csv' => \Orbit\Drivers\Csv::class,
     ],
 
     'paths' => [

--- a/src/Drivers/Csv.php
+++ b/src/Drivers/Csv.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Orbit\Drivers;
+
+use Illuminate\Database\Eloquent\Model;
+use SplFileInfo;
+
+class Csv extends FileDriver
+{
+    protected function dumpContent(Model $model): string
+    {
+        $data = array_filter($this->getModelAttributes($model));
+
+        return implode(',', $data);
+    }
+
+    protected function parseContent(SplFileInfo $file): array
+    {
+        $path = $file->getPathname();
+
+        try {
+            $handle = fopen($path, 'r');
+            $data = fgetcsv($handle);
+        } catch (\Exception $e) {
+            return [];
+        } finally {
+            fclose($handle);
+        }
+
+        return $data;
+    }
+
+    protected function extension(): string
+    {
+        return 'csv';
+    }
+}

--- a/tests/AdvancedOrbitalTest.php
+++ b/tests/AdvancedOrbitalTest.php
@@ -10,6 +10,7 @@ use Orbit\Tests\Fixtures\CustomKey;
 use Orbit\Tests\Fixtures\JsonModel;
 use Orbit\Tests\Fixtures\Post;
 use Orbit\Tests\Fixtures\YamlModel;
+use Orbit\Tests\Fixtures\CsvModel;
 
 class AdvancedOrbitalTest extends TestCase
 {
@@ -18,6 +19,7 @@ class AdvancedOrbitalTest extends TestCase
         CustomKey::all()->each->delete();
         JsonModel::all()->each->delete();
         YamlModel::all()->each->delete();
+        CsvModel::all()->each->delete();
         Post::all()->each->delete();
     }
 
@@ -62,6 +64,16 @@ class AdvancedOrbitalTest extends TestCase
         ]);
 
         $this->assertFileExists(__DIR__.'/content/yaml_models/'.$yaml->getKey().'.yml');
+    }
+
+
+    public function test_it_can_use_csv_driver()
+    {
+        $csv = CsvModel::create([
+            'name' => 'Ryan',
+        ]);
+
+        $this->assertFileExists(__DIR__.'/content/csv_models/'.$csv->getKey().'.csv');
     }
 
     public function test_it_writes_hidden_columns()

--- a/tests/Fixtures/CsvModel.php
+++ b/tests/Fixtures/CsvModel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Orbit\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Orbit\Concerns\Orbital;
+
+class CsvModel extends Model
+{
+    use Orbital;
+
+    protected $guarded = [];
+
+    protected static $driver = 'csv';
+
+    public static function schema(Blueprint $table)
+    {
+        $table->string('name');
+    }
+
+    public function getKeyName()
+    {
+        return 'name';
+    }
+
+    public function getIncrementing()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Hello @ryangjchandler 

Great work with Orbit 👏 

This PR adds CSV driver to the collection of builtin drivers, as CSV is one the of common flat file formats used in data storage, I (@alphaolomi), @brunoalfred and several other colleagues thought it would be best to include in the package.

Thanks in advance.
