### PR TITLE
[2.x] Feature: Add flat json driver

### DIFF
--- a/src/Actions/DeleteSourceFile.php
+++ b/src/Actions/DeleteSourceFile.php
@@ -6,18 +6,32 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Orbit\Contracts\Driver;
 use Orbit\Contracts\Orbit;
+use Orbit\Drivers\FlatJson;
 
 class DeleteSourceFile
 {
     public function execute(Orbit&Model $model, Driver $driver): void
     {
-        $directory = config('orbit.paths.content').DIRECTORY_SEPARATOR.$model->getOrbitSource();
-        $filename = "{$model->getKey()}.{$driver->extension()}";
-
+        $directory = config('orbit.paths.content') . DIRECTORY_SEPARATOR . $model->getOrbitSource();
         $fs = new Filesystem();
 
-        if ($fs->exists($directory.DIRECTORY_SEPARATOR.$filename)) {
-            $fs->delete($directory.DIRECTORY_SEPARATOR.$filename);
+        if ($driver instanceof FlatJson) {
+            $filename = $directory . '.' . $driver->extension();
+            $contents = $fs->exists($filename) ? $fs->get($filename) : '{}';
+            $records = collect($driver->parse($contents))
+                ->keyBy($model->getKeyName())
+                ->forget($model->getKey())
+                ->all();
+
+            $fs->put($filename, $driver->compile($records));
+
+            return;
+        }
+
+        $filename = "{$model->getKey()}.{$driver->extension()}";
+
+        if ($fs->exists($directory . DIRECTORY_SEPARATOR . $filename)) {
+            $fs->delete($directory . DIRECTORY_SEPARATOR . $filename);
         }
     }
 }

--- a/src/Actions/MaybeCreateOrbitDirectories.php
+++ b/src/Actions/MaybeCreateOrbitDirectories.php
@@ -5,6 +5,7 @@ namespace Orbit\Actions;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Orbit\Contracts\Orbit;
+use Orbit\Drivers\FlatJson;
 
 class MaybeCreateOrbitDirectories
 {
@@ -19,8 +20,8 @@ class MaybeCreateOrbitDirectories
             $fs->put(config('orbit.paths.database'), '');
         }
 
-        if ($model !== null) {
-            $modelDirectory = config('orbit.paths.content').DIRECTORY_SEPARATOR.$model->getOrbitSource();
+        if ($model !== null && $model->getOrbitDriver() !== FlatJson::class) {
+            $modelDirectory = config('orbit.paths.content') . DIRECTORY_SEPARATOR . $model->getOrbitSource();
 
             $fs->ensureDirectoryExists($modelDirectory);
         }

--- a/src/Actions/SaveCompiledAttributesToFile.php
+++ b/src/Actions/SaveCompiledAttributesToFile.php
@@ -6,19 +6,37 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Orbit\Contracts\Driver;
 use Orbit\Contracts\Orbit;
+use Orbit\Drivers\FlatJson;
 
 class SaveCompiledAttributesToFile
 {
     public function execute(Orbit&Model $model, string $compiledAttributes, Driver $driver): void
     {
-        $directory = config('orbit.paths.content').DIRECTORY_SEPARATOR.$model->getOrbitSource();
-        $filename = "{$model->getKey()}.{$driver->extension()}";
+        $directory = config('orbit.paths.content') . DIRECTORY_SEPARATOR . $model->getOrbitSource();
         $fs = new Filesystem();
 
-        if ($model->wasChanged($model->getKey())) {
-            $fs->delete($directory.DIRECTORY_SEPARATOR.$model->getOriginal($model->getKeyName()).'.'.$driver->extension());
+        if ($driver instanceof FlatJson) {
+            $filename = $directory . '.' . $driver->extension();
+
+            $contents = $fs->exists($filename) ? $fs->get($filename) : '{}';
+            $rows = collect($driver->parse($contents))
+                ->keyBy($model->getKeyName())
+                ->put(
+                    $model->getKey(),
+                    $driver->parse($compiledAttributes),
+                )
+                ->all();
+
+            $fs->put($filename, $driver->compile($rows));
+            return;
         }
 
-        $fs->put($directory.DIRECTORY_SEPARATOR.$filename, $compiledAttributes);
+        $filename = "{$model->getKey()}.{$driver->extension()}";
+
+        if ($model->wasChanged($model->getKey())) {
+            $fs->delete($directory . DIRECTORY_SEPARATOR . $model->getOriginal($model->getKeyName()) . '.' . $driver->extension());
+        }
+
+        $fs->put($directory . DIRECTORY_SEPARATOR . $filename, $compiledAttributes);
     }
 }

--- a/src/Drivers/FlatJson.php
+++ b/src/Drivers/FlatJson.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Orbit\Drivers;
+
+use Orbit\Contracts\Driver;
+
+class FlatJson extends Json implements Driver {}

--- a/tests/Feature/Orbital/CreateTest.php
+++ b/tests/Feature/Orbital/CreateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tests\Fixtures\Models\FlatJsonModel;
 use Tests\Fixtures\Models\Post;
 
 it('creates a new file when a model is created', function () {
@@ -25,4 +26,28 @@ it('does not use accessors when serialising saved data', function () {
         ->toBeFile()
         ->and(file_get_contents(base_path("content/posts/{$post->id}.md")))
         ->not->toContain('Hello');
+});
+
+it('creates a single file when multiple models are created using the flat json driver', function () {
+    $post1 = FlatJsonModel::create([
+        'title' => 'Example Post 1',
+    ]);
+
+    $post2 = FlatJsonModel::create([
+        'title' => 'Example Post 2',
+    ]);
+
+    expect(base_path("content/flat_json_models.json"))
+        ->toBeFile()
+        ->and(file_get_contents(base_path("content/flat_json_models.json")))
+        ->json()
+        ->toContain([
+            'id' => $post1->id,
+            'title' => 'Example Post 1',
+        ])
+        ->toContain([
+            'id' => $post2->id,
+            'title' => 'Example Post 2',
+        ])
+        ->toHaveKeys([$post1->id, $post2->id]);
 });

--- a/tests/Feature/Orbital/DeleteTest.php
+++ b/tests/Feature/Orbital/DeleteTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tests\Fixtures\Models\FlatJsonModel;
 use Tests\Fixtures\Models\Post;
 
 it('deletes a file when a model is deleted', function () {
@@ -14,4 +15,20 @@ it('deletes a file when a model is deleted', function () {
 
     expect(base_path("content/posts/{$post->id}.md"))
         ->not->toBeFile();
+});
+
+it('deletes a entry from the file when a model is deleted using the flat json driver', function () {
+    $post = FlatJsonModel::create([
+        'title' => 'Example Post',
+    ]);
+
+    expect(base_path("content/flat_json_models.json"))
+        ->toBeFile();
+
+    $post->delete();
+
+    expect(base_path("content/flat_json_models.json"))
+        ->toBeFile()
+        ->and(file_get_contents(base_path("content/flat_json_models.json")))
+        ->not->toContain('Example Post');
 });

--- a/tests/Feature/Orbital/UpdateTest.php
+++ b/tests/Feature/Orbital/UpdateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tests\Fixtures\Models\FlatJsonModel;
 use Tests\Fixtures\Models\Post;
 
 it('updates an existing file when a model is updated', function () {
@@ -26,4 +27,32 @@ it('updates an existing file when a model is updated', function () {
         id: $post->id
         title: 'Updated Example Post'
         MD);
+});
+
+it('updates an entry from the file when a model is updated using the flat json driver', function () {
+    $post = FlatJsonModel::create([
+        'title' => 'Example Post',
+    ]);
+
+    expect(base_path("content/flat_json_models.json"))
+        ->toBeFile()
+        ->and(file_get_contents(base_path("content/flat_json_models.json")))
+        ->json()
+        ->toContain([
+            'id' => $post->id,
+            'title' => 'Example Post',
+        ]);
+
+    $post->update([
+        'title' => 'Updated Example Post',
+    ]);
+
+    expect(base_path("content/flat_json_models.json"))
+        ->toBeFile()
+        ->and(file_get_contents(base_path("content/flat_json_models.json")))
+        ->json()
+        ->toContain([
+            'id' => $post->id,
+            'title' => 'Updated Example Post',
+        ]);
 });

--- a/tests/Fixtures/Models/FlatJsonModel.php
+++ b/tests/Fixtures/Models/FlatJsonModel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Str;
+use Orbit\Concerns\Orbital;
+use Orbit\Contracts\Orbit;
+use Orbit\Drivers\FlatJson;
+
+class FlatJsonModel extends Model implements Orbit
+{
+    use Orbital;
+
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function schema(Blueprint $table): void
+    {
+        $table->id();
+        $table->string('title');
+        $table->longText('content')->nullable();
+    }
+
+    public function title(): Attribute
+    {
+        return Attribute::get(fn(string $value) => Str::headline($value));
+    }
+
+    public function getOrbitDriver(): string
+    {
+        return FlatJson::class;
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,11 +1,13 @@
 <?php
 
 use Tests\Fixtures\Models\Category;
+use Tests\Fixtures\Models\FlatJsonModel;
 use Tests\Fixtures\Models\Post;
 
 uses(Tests\TestCase::class)->in('Feature');
 
 afterEach(function () {
-    Post::all()->each(fn (Post $post) => $post->delete());
-    Category::all()->each(fn (Category $category) => $category->forceDelete());
+    Post::all()->each(fn(Post $post) => $post->delete());
+    FlatJsonModel::all()->each(fn(FlatJsonModel $model) => $model->delete());
+    Category::all()->each(fn(Category $category) => $category->forceDelete());
 });


### PR DESCRIPTION
This is another attempt of https://github.com/ryangjchandler/orbit/pull/151 but with the 2.0 rework

Copying the description:

> This adds a new driver which allows for storage of model data in a flat json file structure. For example, a model named "Post" would store all of its entries in content/posts.json.
> 
> Use case:
> I personally am using this to allow importing whole models into javascript without any api endpoint.

Everything works in this PR but I had to make a lot of changes to core files so maybe there are better ways to do things?  Let me know what you think.