### PR TITLE
Allow for Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/events": "^12.0 | ^13.0",
         "illuminate/support": "^12.0 | ^13.0",
         "spatie/yaml-front-matter": "^2.0",
-        "symfony/yaml": "^6.0 | ^7.0"
+        "symfony/yaml": "^6.0 | ^7.0 | ^8.0"
     },
     "require-dev": {
         "laravel/scout": "^10.0 | ^11.0",


### PR DESCRIPTION
symfony/yaml v8 is a small release with only one breaking change that does not apply to this package:

* Remove support for parsing duplicate mapping keys whose value is `null`

Source: [symfony/yaml v7 ... v8](https://github.com/symfony/yaml/compare/v7.4.6...v8.0.6) diff